### PR TITLE
Make possible to work on system without cgroups

### DIFF
--- a/runner/command.sh
+++ b/runner/command.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
-
-mem_limit_bytes=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
-mem_limit_Mbytes=`expr $mem_limit_bytes / 1048576`
+if [[ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+    mem_limit_bytes=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
+    mem_limit_Mbytes=`expr $mem_limit_bytes / 1048576`
+else 
+    mem_limit_Mbytes=512
+fi
 
 node () {
     `which node` --max-old-space-size=$mem_limit_Mbytes $@


### PR DESCRIPTION
make apprunner work on systems, where are no cgroups